### PR TITLE
Enable local preview without credentials

### DIFF
--- a/.env
+++ b/.env
@@ -3,3 +3,4 @@ FIREBASE_PRIVATE_KEY=-----BEGIN PRIVATE KEY-----
 FAKEKEYMATERIAL
 -----END PRIVATE KEY-----
 FIREBASE_CLIENT_EMAIL=your-client-email-here
+DATABASE_URL=postgres://user:password@localhost:5432/rhymebuilder

--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# RhymeBuilder
+
+This project is a React + Express application. The default `npm run dev` script starts both the client and the API server on port `5000`.
+
+## Local Development
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Copy `.env.example` to `.env` and adjust the variables if desired. The repository includes a minimal `.env` with placeholder values so the server can start without external services.
+3. Start the development server:
+   ```bash
+   npm run dev
+   ```
+   The app will be served at [http://localhost:5000](http://localhost:5000).
+
+## Mobile Preview
+
+To preview the app on a mobile device, open the running URL in your browser's developer tools and enable a mobile viewport (for example Chrome DevTools device emulation). The layout adapts to screens under 768px width.
+

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,3 +1,5 @@
+import "dotenv/config";
+
 console.log('FIREBASE_PROJECT_ID:', process.env.FIREBASE_PROJECT_ID);
 console.log('FIREBASE_PRIVATE_KEY:', process.env.FIREBASE_PRIVATE_KEY);
 console.log('FIREBASE_CLIENT_EMAIL:', process.env.FIREBASE_CLIENT_EMAIL);
@@ -42,8 +44,13 @@ app.use((req, res, next) => {
 
 (async () => {
   app.use('/api', router);
-  const server = app.listen(5000, () => {
-    log('serving on port 5000');
+  const port = 5000;
+  const server = app.listen({
+    port,
+    host: '0.0.0.0',
+    reusePort: false,
+  }, () => {
+    log(`serving on port ${port}`);
   });
 
   app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
@@ -63,15 +70,5 @@ app.use((req, res, next) => {
     serveStatic(app);
   }
 
-  // ALWAYS serve the app on port 5000
-  // this serves both the API and the client.
-  // It is the only port that is not firewalled.
-  const port = 5000;
-  server.listen({
-    port,
-    host: "0.0.0.0",
-    reusePort: false,
-  }, () => {
-    log(`serving on port ${port}`);
-  });
+  // The "server" instance is already listening. Nothing else to do here.
 })();

--- a/server/services/firebase.ts
+++ b/server/services/firebase.ts
@@ -1,7 +1,16 @@
 import admin from 'firebase-admin';
 import { Request, Response, NextFunction } from 'express';
 
-if (!admin.apps.length) {
+const hasCredentials = Boolean(
+  process.env.FIREBASE_PROJECT_ID &&
+    !process.env.FIREBASE_PROJECT_ID?.includes('your-project') &&
+    process.env.FIREBASE_PRIVATE_KEY &&
+    !process.env.FIREBASE_PRIVATE_KEY?.includes('FAKE') &&
+    process.env.FIREBASE_CLIENT_EMAIL &&
+    !process.env.FIREBASE_CLIENT_EMAIL?.includes('your-'),
+);
+
+if (hasCredentials && !admin.apps.length) {
   admin.initializeApp({
     credential: admin.credential.cert({
       projectId: process.env.FIREBASE_PROJECT_ID,
@@ -9,9 +18,20 @@ if (!admin.apps.length) {
       clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
     }),
   });
+} else if (!hasCredentials) {
+  console.warn('Firebase credentials not found. Skipping initialization.');
 }
 
-export const verifyFirebaseToken = async (req: Request, res: Response, next: NextFunction) => {
+export const verifyFirebaseToken = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  if (!hasCredentials) {
+    // When credentials are missing, skip verification for easier local testing.
+    return next();
+  }
+
   const authHeader = req.headers.authorization;
   if (!authHeader) return res.status(401).json({ error: 'Missing Authorization header' });
 


### PR DESCRIPTION
## Summary
- allow server to load environment variables via dotenv
- skip Firebase initialization when credentials aren't provided and bypass auth checks
- fix server startup to avoid double `listen` call
- include a placeholder database URL in `.env`
- add README with local/mobile preview instructions

## Testing
- `npm run dev` *(fails: Node cannot run due to environment)*